### PR TITLE
Revisit of the visitor pattern.

### DIFF
--- a/Source/Weavers/NSubstitute.Weaver/MockWeaver/MockInjectorVisitor.cs
+++ b/Source/Weavers/NSubstitute.Weaver/MockWeaver/MockInjectorVisitor.cs
@@ -94,6 +94,13 @@ namespace NSubstitute.Weaver
             else
             {
                 ctor = ctors.First();
+                if (ctor.Body == null)
+                {
+                    var methodDefinition = new MethodDefinition(".ctor",
+                        MethodAttributes.Public | MethodAttributes.RTSpecialName | MethodAttributes.SpecialName |
+                        MethodAttributes.HideBySig, typeDefinition.Module.TypeSystem.Void);
+                    ctor.Body = new MethodBody(methodDefinition);
+                }
                 ctor.IsPublic = true;
             }
 

--- a/Source/Weavers/NSubstitute.Weaver/MockWeaver/MockInjectorVisitor.cs
+++ b/Source/Weavers/NSubstitute.Weaver/MockWeaver/MockInjectorVisitor.cs
@@ -96,10 +96,7 @@ namespace NSubstitute.Weaver
                 ctor = ctors.First();
                 if (ctor.Body == null)
                 {
-                    var methodDefinition = new MethodDefinition(".ctor",
-                        MethodAttributes.Public | MethodAttributes.RTSpecialName | MethodAttributes.SpecialName |
-                        MethodAttributes.HideBySig, typeDefinition.Module.TypeSystem.Void);
-                    ctor.Body = new MethodBody(methodDefinition);
+                    ctor.Body = new MethodBody(ctor);
                 }
                 ctor.IsPublic = true;
             }

--- a/Source/Weavers/NSubstitute.Weaver/MscorlibWeaver/MscorlibWrapper/ProcessTypeResolver.cs
+++ b/Source/Weavers/NSubstitute.Weaver/MscorlibWeaver/MscorlibWrapper/ProcessTypeResolver.cs
@@ -1,6 +1,7 @@
 using System.Collections.Generic;
 using System.Linq;
 using Mono.Cecil;
+using Unity.Cecil.Visitor;
 
 namespace NSubstitute.Weaver
 {
@@ -13,14 +14,6 @@ namespace NSubstitute.Weaver
             m_Assembly = assembly;
         }
 
-        static int InheritanceChainLength(TypeReference type)
-        {
-            var baseType = type.Resolve().BaseType;
-            if (baseType == null)
-                return 1;
-            return 1 + InheritanceChainLength(baseType);
-        }
-
         public IEnumerable<TypeDefinition> Resolve(IEnumerable<string> typesToCopy)
         {
             var toCopy = new HashSet<string>(typesToCopy);
@@ -28,8 +21,8 @@ namespace NSubstitute.Weaver
             var types = new List<TypeDefinition>(m_Assembly.MainModule.Types.Where(t => toCopy.Contains(t.FullName)));
             types.Sort((lhs, rhs) =>
                 {
-                    var lhsChain = InheritanceChainLength(lhs);
-                    var rhsChain = InheritanceChainLength(rhs);
+                    var lhsChain = TypeReferenceExtensions.InheritanceChainLength(lhs);
+                    var rhsChain = TypeReferenceExtensions.InheritanceChainLength(rhs);
                     return lhsChain.CompareTo(rhsChain);
                 });
             return types;

--- a/Source/Weavers/Unity.Cecil.Visitor/TypeReferenceExtensions.cs
+++ b/Source/Weavers/Unity.Cecil.Visitor/TypeReferenceExtensions.cs
@@ -1,0 +1,15 @@
+﻿using Mono.Cecil;
+
+namespace Unity.Cecil.Visitor
+{
+    public static class TypeReferenceExtensions
+    {
+        public static int InheritanceChainLength(TypeReference type)
+        {
+            var baseType = type.Resolve().BaseType;
+            if (baseType == null)
+                return 1;
+            return 1 + InheritanceChainLength(baseType);
+        }
+    }
+}

--- a/Source/Weavers/Unity.Cecil.Visitor/Unity.Cecil.Visitor.csproj
+++ b/Source/Weavers/Unity.Cecil.Visitor/Unity.Cecil.Visitor.csproj
@@ -12,6 +12,7 @@
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="Extensions.cs" />
+    <Compile Include="TypeReferenceExtensions.cs" />
     <Compile Include="Visitor.cs" />
   </ItemGroup>
   <ItemGroup>

--- a/Source/Weavers/Unity.Cecil.Visitor/Visitor.cs
+++ b/Source/Weavers/Unity.Cecil.Visitor/Visitor.cs
@@ -1,7 +1,10 @@
 using System;
+using System.Collections.Generic;
+using System.Linq;
 using System.Reflection;
 using Mono.Cecil;
 using Mono.Cecil.Cil;
+using Mono.Collections.Generic;
 
 namespace Unity.Cecil.Visitor
 {
@@ -254,9 +257,42 @@ namespace Unity.Cecil.Visitor
 
         protected virtual void Visit(ModuleDefinition moduleDefinition, Context context)
         {
+            var searchedDefinitions = new Dictionary<string, bool>();
             foreach (var typeDefinition in moduleDefinition.Types)
+            {
+                VisitBase(typeDefinition, moduleDefinition.Types, context.Member(moduleDefinition), searchedDefinitions);
+            }
+        }
 
-                Visit(typeDefinition, context.Member(moduleDefinition));
+        /// <summary>
+        /// We recursively go down the inheritance path, until we reach a type definition without a base class.
+        /// Type definitions in the "System." packages are not considered.
+        /// </summary>
+        /// <param name="typeDefinition">Current head in the visitor pattern path.</param>
+        /// <param name="moduleDefinitionTypes">Collection used to locate the base type definition.</param>
+        /// <param name="context">Context to be passed to <code>Visit(TypeDefinition, Context)</code>.</param>
+        /// <param name="searchedDefinitions"><code>Dictionary</code> used to avoid more than one processing of the same type.</param>
+        protected virtual void VisitBase(TypeDefinition typeDefinition,
+            Collection<TypeDefinition> moduleDefinitionTypes, Context context,
+            Dictionary<string, bool> searchedDefinitions)
+        {
+            if (searchedDefinitions.ContainsKey(typeDefinition.FullName))
+            {
+                return;
+            }
+
+            if (typeDefinition.BaseType != null && !searchedDefinitions.ContainsKey(typeDefinition.BaseType.FullName)
+                && !typeDefinition.BaseType.FullName.StartsWith("System"))
+            {
+                var baseType = moduleDefinitionTypes.FirstOrDefault(definition =>
+                    definition.FullName.Equals(typeDefinition.BaseType.FullName));
+                if (baseType != default(TypeDefinition))
+                {
+                    VisitBase(baseType, moduleDefinitionTypes, context, searchedDefinitions);
+                }
+            }
+            searchedDefinitions.Add(typeDefinition.FullName, true);
+            Visit(typeDefinition, context);
         }
 
         protected virtual void Visit(TypeDefinition typeDefinition, Context context)


### PR DESCRIPTION
As the type inheritance is not being taken into consideration it has now been implemented.
Iteration of type definitions are done by going to the base class.
This makes sure that all default constructors are generated before processing a class.

In order to fix empty constructors without bodies, the body is being constructed inside MockInjectorVisitor in the same way as when constructing a new empty constructor.